### PR TITLE
added Tool.trace line before file dialogue fixes mac version

### DIFF
--- a/org/fairsim/sim_gui/DefineMachineGui.java
+++ b/org/fairsim/sim_gui/DefineMachineGui.java
@@ -170,7 +170,8 @@ public class DefineMachineGui {
 	JFileChooser fc = new JFileChooser();
 	if ( initialFolder != null ) {
 	    fc.setCurrentDirectory( initialFolder );
-	}
+	}	
+	Tool.trace("set path:\n");
 	int returnVal = fc.showOpenDialog(baseframe);
 
         if (returnVal == JFileChooser.APPROVE_OPTION) {


### PR DESCRIPTION
Very strange behaviour. On my mac building with the Tool.trace in works, removing it locks imageJ before the file dialogue appears. I assume it is some strange thread/gui interaction. 